### PR TITLE
Widen version of six to avoid dependency conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,6 @@ setup(
         'django-appconf >= 1.0',
         'rcssmin == 1.0.6',
         'rjsmin == 1.1.0',
-        'six == 1.12.0',
+        'six >= 1.12.0',
     ],
 )


### PR DESCRIPTION
Widen version requirement of six to avoid dependency conflicts on some packages