### PR TITLE
Fix import error for django 4.0

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -8,8 +8,14 @@ from importlib import import_module
 import six
 from django.core.cache import caches
 from django.core.files.base import ContentFile
-from django.utils.encoding import force_text, smart_bytes
+from django.utils.encoding import smart_bytes
 from django.utils.functional import SimpleLazyObject
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str
+    force_text = force_str
 
 from compressor.conf import settings
 from compressor.storage import default_storage


### PR DESCRIPTION
The force_text function has been deprecated from django 4.0 and is replaced by force_str. To work with both django 4.0 and earlier versions, we try to import force_text, and if that fails, we import force_str and creates an alias function called force_text.