### PR TITLE
Fix import error for django 4.0

### DIFF
--- a/compressor/cache.py
+++ b/compressor/cache.py
@@ -10,13 +10,7 @@ from django.core.cache import caches
 from django.core.files.base import ContentFile
 from django.utils.encoding import smart_bytes
 from django.utils.functional import SimpleLazyObject
-
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_str
-    force_text = force_str
-
+from compressor.compatible import force_text
 from compressor.conf import settings
 from compressor.storage import default_storage
 from compressor.utils import get_mod_func

--- a/compressor/compatible.py
+++ b/compressor/compatible.py
@@ -1,0 +1,11 @@
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_str
+    force_text = force_str

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -22,7 +22,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 
 import six
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
 
 from compressor.cache import cache, get_precompiler_cachekey
 

--- a/compressor/filters/base.py
+++ b/compressor/filters/base.py
@@ -22,13 +22,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.temp import NamedTemporaryFile
 
 import six
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
-
+from compressor.compatible import smart_text
 from compressor.cache import cache, get_precompiler_cachekey
 
 from compressor.conf import settings

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -12,13 +12,7 @@ import six
 from django.core.management.base import BaseCommand, CommandError
 import django.template
 from django.template import Context
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
-
+from compressor.compatible import smart_text
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from django.template import engines
 

--- a/compressor/management/commands/compress.py
+++ b/compressor/management/commands/compress.py
@@ -12,7 +12,13 @@ import six
 from django.core.management.base import BaseCommand, CommandError
 import django.template
 from django.template import Context
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
+
 from django.template.loader import get_template  # noqa Leave this in to preload template locations
 from django.template import engines
 

--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -1,11 +1,6 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
+from compressor.compatible import smart_text
 
 from compressor.parser import ParserBase
 

--- a/compressor/parser/beautifulsoup.py
+++ b/compressor/parser/beautifulsoup.py
@@ -1,6 +1,11 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
 
 from compressor.parser import ParserBase
 

--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -1,12 +1,7 @@
 import sys
 
 import six
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
+from compressor.compatible import smart_text
 
 from compressor.exceptions import ParserError
 from compressor.parser import ParserBase

--- a/compressor/parser/default_htmlparser.py
+++ b/compressor/parser/default_htmlparser.py
@@ -1,7 +1,12 @@
 import sys
 
 import six
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
 
 from compressor.exceptions import ParserError
 from compressor.parser import ParserBase

--- a/compressor/parser/html5lib.py
+++ b/compressor/parser/html5lib.py
@@ -1,12 +1,6 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
-
+from compressor.compatible import smart_text
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError

--- a/compressor/parser/html5lib.py
+++ b/compressor/parser/html5lib.py
@@ -1,6 +1,12 @@
 from __future__ import absolute_import
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
+
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError

--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import, unicode_literals
 
 import six
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
+
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError

--- a/compressor/parser/lxml.py
+++ b/compressor/parser/lxml.py
@@ -2,13 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import six
 from django.core.exceptions import ImproperlyConfigured
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
-
+from compressor.compatible import smart_text
 from django.utils.functional import cached_property
 
 from compressor.exceptions import ParserError

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -6,12 +6,7 @@ import sys
 import mock
 
 import six
-
-try:
-    from django.utils.encoding import smart_text
-except ImportError:
-    from django.utils.encoding import smart_str
-    smart_text = smart_str
+from compressor.compatible import smart_text
 
 from django.test import TestCase
 from django.test.utils import override_settings

--- a/compressor/tests/test_filters.py
+++ b/compressor/tests/test_filters.py
@@ -6,7 +6,13 @@ import sys
 import mock
 
 import six
-from django.utils.encoding import smart_text
+
+try:
+    from django.utils.encoding import smart_text
+except ImportError:
+    from django.utils.encoding import smart_str
+    smart_text = smart_str
+
 from django.test import TestCase
 from django.test.utils import override_settings
 


### PR DESCRIPTION
The smart_text function has been deprecated from django 4.0 and is replaced by smart_text. To work with both django 4.0 and earlier versions, we try to import smart_text, and if that fails, we import smart_str and create an alias function called smart_text.